### PR TITLE
Fixed so that Server always connects to MongoDB Atlas before starting

### DIFF
--- a/server/controllers/DBController.js
+++ b/server/controllers/DBController.js
@@ -1,10 +1,13 @@
 const mongoose = require("mongoose");
 require("dotenv").config();
 
-mongoose.connect(process.env.DB_CONNECT, {
-    useUnifiedTopology: true,
-    useNewUrlParser: true,
-});
-mongoose.connection.once("open", () => {
-    console.log("Server connected to MongoDB Atlas");
-});
+exports.connectServerToDB = (app) => {
+    mongoose.connect(process.env.DB_CONNECT, {
+        useUnifiedTopology: true,
+        useNewUrlParser: true,
+    });
+    mongoose.connection.once("open", () => {
+        app.emit("mongodb_connection_ready");
+        console.log("Server connected to MongoDB Atlas");
+    });
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,9 @@
 const express = require("express");
-
-const dotenv = require("dotenv");
 const cors = require("cors");
+require("dotenv").config();
+const dbController = require("./controllers/DBController");
 
 const app = express();
-dotenv.config();
 
 /* Middleware */
 app.use(express.urlencoded({ extended: false }));
@@ -15,8 +14,10 @@ app.use(cors());
 const authAPI = require("./api/routes/authAPI");
 app.use("/", authAPI);
 
-require("./controllers/DBController");
+dbController.connectServerToDB(app);
 
-app.listen(process.env.SERVER_PORT, () => {
-    console.log(`Server listening on port ${process.env.SERVER_PORT}`);
+app.on("mongodb_connection_ready", () => {
+    app.listen(process.env.SERVER_PORT, () => {
+        console.log(`Server listening on port ${process.env.SERVER_PORT}`);
+    });
 });


### PR DESCRIPTION
The DBController.js now emits a signal using the 'app' object when it has finished connecting to MongoDB Atlas, which means
that the Server will always be connected to the cloud DB before running app.listen()