### PR TITLE
Changed back GET /auth/userstatus/ to older version

### DIFF
--- a/server/api/routes/authAPI.js
+++ b/server/api/routes/authAPI.js
@@ -235,7 +235,11 @@ router.get("/auth/userstatus", async (req, res) => {
             responseHandler.sendResponse(result, res);
         }
     } catch (error) {
-        if (error.code || error.name === 'JsonWebTokenError') {
+        /* possible that this is needed:
+            if (error.code || error.name === "JsonWebTokenError" || error.name === "TokenExpiredError")
+           but I don't think so
+        */
+        if (error.code) {
             responseHandler.sendResponse(
                 {
                     isError: true,


### PR DESCRIPTION
Reverted GET /auth/userstatus/ to an older version where every invalid token error is handled by the same if-clause.
If it doesn't work the other solution is featured as a comment above the new function.